### PR TITLE
Fix injecting Permissions item into context menu when user has no roles

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Permission Viewer",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Simple permission viewer which can be used to see what permissions a user has as well as what role it originated from",
   "author": "Joakim#9814",
   "license": "MIT",


### PR DESCRIPTION
When users have no roles, Discord no longer adds the "Roles" item to the user context menu, which causes injection based on that item alone to fail. This works around that by adding a fallback location for the "Permissions" menu item: if no "Roles" item is found, then the "Permissions" item is added to the area below the one containing the "Block" or "Unblock" button. (In my testing, this area is always invisible unless Permissions is added to it.)

I've also bumped the version number to 0.0.4.