### PR TITLE
Fix menu item placement for self when owner w/o roles

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,7 +153,7 @@ module.exports = class PermissionViewer extends Plugin {
           if (c && c.props) {
             if (c.props.id === 'roles') {
               return true;
-            } else if (c.props.id === 'block') {
+            } else if (c.props.id === 'block' || c.props.id === 'change-nickname') {
               blockAreaIndex = childIndex;
             }
           }


### PR DESCRIPTION
In the case where the user being inspected is the "self" (logged-in) user and has no roles, there is no "Block" menu item like there would be for another user, so the previously merged fallback fails.

This PR adds yet another fallback: you will always have an "Edit Server Profile" (formerly "Change Nickname") menu option regardless of your permissions, and this is conveniently in the same menu area where the "Block" button is or would be. Thus, the correct menu area can still be determined from the Edit Server Profile item if no Block button is present.

This way, the Permissions menu item for one's own account shows up where the user is expecting it, near the bottom of the context menu, rather than in the first section as it was doing in my previous PR.